### PR TITLE
Update DbUrlList to use symbol operators

### DIFF
--- a/lib/DbUrlList.js
+++ b/lib/DbUrlList.js
@@ -2,6 +2,7 @@ var DbUrlList,
     Promise = require("bluebird"),
     Url = require("./Url"),
     Sequelize = require('sequelize'),
+    Op = Sequelize.Op,
     crypto = require("crypto"),
     YEAR_MS = 31536000000;
 
@@ -259,7 +260,7 @@ DbUrlList.prototype.getNextUrl = function () {
     return urlTable.findOne({
       where: {
         nextRetryDate: {
-          $lt: new Date()
+          [Op.lt]: new Date()
         }
       },
       order: ["nextRetryDate"]


### PR DESCRIPTION
The DbUrlList.getNextUrl function was failing on Postgres when I tried
to use it. After some exploration, I discovered the use of `$lt`. I
changed the code to use [Op.lt] and getNextUrl started working as
expected.

Also, Sequelize says it is highly advised to use symbol operators from
Sequelize.Op and not depend on any string based operators.