### PR TITLE
Add error message to 'crawledurl' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The `Crawler` object fires the following events:
 | Event | Description |
 | --- | --- |
 | crawlurl(url) | Fires when crawling starts with a new URL. |
-| crawledurl(url, errorCode, statusCode) | Fires when crawling of a URL is complete. `errorCode` is `null` if no error occurred. `statusCode` is set if and only if the request was successful. |
+| crawledurl(url, errorCode, statusCode, errorMessage) | Fires when crawling of a URL is complete. `errorCode` is `null` if no error occurred. `statusCode` is set if and only if the request was successful. `errorMessage` is `null` if no error occurred. |
 | urllistempty | Fires when the URL list is (intermittently) empty. |
 | urllistcomplete | Fires when the URL list is permanently empty, barring URLs added by external sources. This only makes sense when running Supercrawler in non-distributed fashion. |
 

--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -309,7 +309,7 @@ Crawler.prototype._processUrl = function (url) {
       errorMessage: err.message
     });
   }).then(function (url) {
-    self.emit("crawledurl", url.getUrl(), url.getErrorCode(), url.getStatusCode());
+    self.emit("crawledurl", url.getUrl(), url.getErrorCode(), url.getStatusCode(), url.getErrorMessage());
 
     return url;
   });

--- a/test/Crawler.spec.js
+++ b/test/Crawler.spec.js
@@ -1017,7 +1017,7 @@ describe("Crawler", function () {
 
       setTimeout(function () {
         crawler.stop();
-        sinon.assert.calledWith(spy, "https://example.com/index1.html", "OTHER_ERROR", null);
+        sinon.assert.calledWith(spy, "https://example.com/index1.html", "OTHER_ERROR", null, "abitrary error");
         done();
       }, 200);
     });


### PR DESCRIPTION
The error message is added to the 'crawledurl' event so tasks, such as
structured logging, can record the specific reason an error occurred.